### PR TITLE
docs: Add tech stack section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ Electron + TypeScript + React + Tailwind CSS + SQLite で構築した、業務�
 - Excel 出力（Excel XML）
 - CSV 出力
 
+## Tech Stack
+
+- Electron
+- TypeScript
+- React
+- Tailwind CSS
+- SQLite (better-sqlite3)
+
 ## セットアップ
 
 ```bash


### PR DESCRIPTION
## Summary

- Add a "Tech Stack" section to README.md listing the core technologies used in the project
- Section is placed between "機能" and "セットアップ" for logical flow

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm Tech Stack section appears between 機能 and セットアップ sections

Generated with [Claude Code](https://claude.ai/claude-code)