### PR TITLE
docs: Fix SQLite dependency name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Electron + TypeScript + React + Tailwind CSS + SQLite で構築した、業務�
 - TypeScript
 - React
 - Tailwind CSS
-- SQLite (better-sqlite3)
+- SQLite (node:sqlite built-in)
 
 ## セットアップ
 


### PR DESCRIPTION
README の SQLite 依存表記を修正（better-sqlite3 → node:sqlite）